### PR TITLE
Now parsing an int from maxConnections and maxIdleTime

### DIFF
--- a/server/config/settings.js
+++ b/server/config/settings.js
@@ -43,8 +43,8 @@ module.exports = {
             password      : process.env.RDS_PASSWORD || nconf.get("db:config:password"),
             databaseName  : nconf.get("db:config:databaseName"),
             pool          : {
-                maxConnections : parseInt(nconf.get("db.config.pool.maxConnections"), 10),
-                maxIdleTime : parseInt(nconf.get("db.config.pool.maxIdleTime"), 10)
+                maxConnections : parseInt(nconf.get("db:config:pool:maxConnections"), 10),
+                maxIdleTime : parseInt(nconf.get("db:config:pool:maxIdleTime"), 10)
             },
         };
     },


### PR DESCRIPTION
Take two - trying to ensure that the maxConnections and maxIdleTime are both integers instead of strings.

Messed up the separation in the namespace used by nconf, correctly using colons now.
