### PR TITLE
Added lables for youngest and oldest instances in instances view

### DIFF
--- a/client/js/templates/instances.template
+++ b/client/js/templates/instances.template
@@ -20,7 +20,7 @@
 	 			<div class="panel-heading">
 	 				<div>{{ip}} 
 						<div class="pull-right text-muted">
-							{#if isOldest}} <span class="label label-warning">Oldest</span> {{/if}}
+							{{#if isOldest}} <span class="label label-warning">Oldest</span> {{/if}}
 							{{#if isYoungest}} <span class="label label-info">Youngest</span> {{/if}}
 							First seen {{formatDate createdAt}}
 						</div>

--- a/client/js/views/instancesView.js
+++ b/client/js/views/instancesView.js
@@ -69,10 +69,12 @@ function($, Backbone, _, Broadcast, InstancesCollection, FilterModel, instancesT
                 youngestInstance = null;
 
             // determine oldest and youngest instance (e.g. first, last)
-            oldestInstance = _.min(this.instances.toJSON(), 
-                                   function(instance) { return new Date(instance.createdAt); });
-            youngestInstance = _.max(this.instances.toJSON(), 
-                                     function(instance) { return new Date(instance.createdAt); });
+            if (this.instances.length > 1) {
+                oldestInstance = _.min(this.instances.toJSON(), 
+                                       function(instance) { return new Date(instance.createdAt); });
+                youngestInstance = _.max(this.instances.toJSON(), 
+                                         function(instance) { return new Date(instance.createdAt); });
+            }
 
             if (_.keys(filtersJson).length > 0) {
                 _.each(this.instances.toJSON(), function(instance) {
@@ -97,8 +99,8 @@ function($, Backbone, _, Broadcast, InstancesCollection, FilterModel, instancesT
             // Handlebars doesn't consider '{}' to be falsy with #if
             _.each(filteredSet, function(instance) {
                 instance.hasMetadata = !_.isEmpty(instance.metadata);
-                instance.isOldest = (instance.ip === oldestInstance.ip);
-                instance.isYoungest = (instance.ip === youngestInstance.ip);
+                instance.isOldest = oldestInstance !== null && (instance.ip === oldestInstance.ip);
+                instance.isYoungest = oldestInstance !== null && (instance.ip === youngestInstance.ip);
             });
 
             data.instances = filteredSet;
@@ -106,6 +108,7 @@ function($, Backbone, _, Broadcast, InstancesCollection, FilterModel, instancesT
             data.showing = filteredSet.length;
             data.total = this.total;
 
+            console.log(data);
             this.$el.html(instancesTemplate(data));
         },
 


### PR DESCRIPTION
The labels are added to make it easy to find the oldest or youngest
instance for a role at a glance.  This is especially useful when
deciding which instances to terminate or which ones to check for
latest updates.

![image](https://cloud.githubusercontent.com/assets/7783905/3248306/6cf0b2ea-f18d-11e3-80ed-67bd9c688cff.png)
