### PR TITLE
Deprecated Winston.transport.DailyRotateFile in favor of simple file logging

### DIFF
--- a/client/bower.json
+++ b/client/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "conqueso",
-    "version": "0.4.4",
+    "version": "0.5.0",
 
     "dependencies" : {
         "jquery"                    : "2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name" : "conqueso",
-    "version" : "0.4.4",
+    "version" : "0.5.0",
     "description" : "Conqueso is a web server that provides an interface for centrally managing dynamic properties across your services. Simply add a client library to your service then track and manage its configuration in Conqueso.",
     "repository": {
         "type": "git",

--- a/server/config/settings.js
+++ b/server/config/settings.js
@@ -63,5 +63,9 @@ module.exports = {
 
     getLogOutputFile: function() {
         return nconf.get("logging:file");
+    },
+
+    getLogType: function() {
+      return nconf.get("logging:type");
     }
 };

--- a/server/config/settings.json
+++ b/server/config/settings.json
@@ -17,6 +17,7 @@
         "pollIntervalSecs" : 15
     },
     "logging" : {
+        "type"   : "file",
         "dir"    : "logs",
         "file"   : "server.log",
         "level"  : "info"

--- a/server/logger.js
+++ b/server/logger.js
@@ -16,7 +16,7 @@
 
 /**
  * Provides console and file logging
- * 
+ *
  * @module logger
  **/
 
@@ -44,9 +44,8 @@ _logger = new (winston.Logger)({
 			json: false,
 			handleExceptions: true
 		}),
-		new (winston.transports.DailyRotateFile)({
+		new (winston.transports.File)({
 			level : loggingLevel,
-			maxsize : 10485760, // 10 MB
 			filename: outputDir + "/" + outputFile,
 			json: false,
 			handleExceptions: true

--- a/server/logger.js
+++ b/server/logger.js
@@ -34,6 +34,24 @@ fs.exists(outputDir, function(exists) {
 	}
 });
 
+var fileLoggingConfig = {
+	level : loggingLevel,
+	filename: outputDir + "/" + outputFile,
+	json: false,
+	handleExceptions: true
+};
+
+// To maintain backward compatibility users have to specify the new 'file'
+// logging type in settings.js. The default settings include it, but if
+// the user changes it or removes it, Conqueso will fall back to the
+//  DailyRotateFile transport.
+if (config.getLogType() === "file") {
+	var fileTransport = new (winston.transports.File)(fileLoggingConfig);
+} else {
+	fileLoggingConfig.maxsize = 10485760;
+	var fileTransport = new (winston.transports.DailyRotateFile)(fileLoggingConfig);
+}
+
 _logger = new (winston.Logger)({
 	levels : {error: 3, warn: 2, info: 1, debug: 0},
 	colors: winston.config.syslog.colors,
@@ -44,12 +62,7 @@ _logger = new (winston.Logger)({
 			json: false,
 			handleExceptions: true
 		}),
-		new (winston.transports.File)({
-			level : loggingLevel,
-			filename: outputDir + "/" + outputFile,
-			json: false,
-			handleExceptions: true
-		})
+		fileTransport
 	]
 });
 


### PR DESCRIPTION
Winston now logs to a single file. Log rotation should be handled at the system level with logrotate.