### PR TITLE
Clear sql modes for sql 8 database - local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       MYSQL_ROOT_PASSWORD: root
     ports:
       - 3307:3306
-
+    command: mysqld --sql_mode=""
 
   conqueso:
     build: .


### PR DESCRIPTION
h1. Why?
For local dev when trying to create the LES database, you will encounter errors running `platform-licence-service-app` unless the modes are cleared from the mysql database. 

h1. What?
The default modes that we are clearing with this command are listed here: https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html