### PR TITLE
Updated Docker to run using Node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # these node images comes with yarn preinstalled.
-FROM node:20.2.0
+FROM node:20
+ENV NODE_OPTIONS=--openssl-legacy-provider
 COPY . /app
 WORKDIR /app
 RUN yarn install


### PR DESCRIPTION
This required a new environment variable due to an update between Node 16 and 17 to OpenSSLv3.0.